### PR TITLE
Add support for Ruby 3.2.0 in Faraday v1.x (#1483)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.4', '2.5', '2.6', '2.7', '3.0']
+        ruby: ['2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2']
 
     steps:
     - uses: actions/checkout@v1

--- a/lib/faraday/dependency_loader.rb
+++ b/lib/faraday/dependency_loader.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'ruby2_keywords'
+
 module Faraday
   # DependencyLoader helps Faraday adapters and middleware load dependencies.
   module DependencyLoader
@@ -13,7 +15,7 @@ module Faraday
       self.load_error = e
     end
 
-    def new(*)
+    ruby2_keywords def new(*)
       unless loaded?
         raise "missing dependency for #{self}: #{load_error.message}"
       end


### PR DESCRIPTION
I backported this fix to v1.4.1 https://github.com/lostisland/faraday/pull/1483 f